### PR TITLE
Add Valid User Endpoint

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -12,6 +12,8 @@ from app.deps.users import current_superuser
 from app.models.user import User
 from app.schemas.user import UserRead
 
+import requests
+
 router = APIRouter()
 
 
@@ -30,3 +32,32 @@ async def get_users(
     )
     response.headers["Content-Range"] = f"{skip}-{skip + len(users)}/{total}"
     return users
+
+@router.get("/users/valid", response_model=List[UserRead])
+async def get_valid_users(
+    response: Response,
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_superuser),
+    skip: int = 0,
+    limit: int = 100,
+) -> Any:
+    logger.info("Fetching valid users")
+    total = await session.scalar(select(func.count(User.id)))
+    users = (
+        (await session.execute(select(User).offset(skip).limit(limit))).scalars().all()
+    )
+    valid_users = list(filter(is_user_valid, users))
+    response.headers["Content-Range"] = f"{skip}-{skip + len(valid_users)}/{total}"
+    return valid_users
+
+
+def is_user_valid(user: User):
+    """Helper function that checks if a user is valid via their email domain
+    """
+    domain = user.email.split("@")[1]
+    
+    try:
+        response = requests.get(f"http://{domain}")
+        return response.status_code == 200
+    except requests.exceptions.ConnectionError:
+        return False

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -1,0 +1,19 @@
+from httpx import AsyncClient
+
+from app.core.config import settings
+from app.models.user import User
+
+from tests.utils import get_jwt_header
+
+class TestGetValidUsers:
+    async def test_get_valid_users_not_logged_in(self, client: AsyncClient):
+        resp = await client.get(settings.API_PATH + "/users/valid")
+        assert resp.status_code == 401
+
+    async def test_get_valid_users_with_unauthorized_user(self, client: AsyncClient, create_user):
+        """ Test that an unauthorized user cannot access the endpoint
+        """
+        user: User = await create_user()
+        jwt_header = get_jwt_header(user)
+        resp = await client.get(settings.API_PATH + "/users/valid", headers=jwt_header)
+        assert resp.status_code == 403


### PR DESCRIPTION
### Description

- Added an endpoint ```/users/valid``` which returns only "valid" users

### Screenshots:
- Application running after executing `docker-compose up`
<img width="50%" height=50% src="https://github.com/assign-guard-dev-team/interview-engineer-software/assets/106280979/4fae3664-f8b0-448b-ba9f-912f4eb31b10">

- Postman after executing a successful call to `/users/valid`
<img width=50% height=50% src="https://github.com/assign-guard-dev-team/interview-engineer-software/assets/106280979/91002336-8184-4e37-96eb-de9e22ebfb42">

### Notes
- I also included some of the Postman tests cases I created below.

```javascript
pm.test("Status code is 200", function () {
    pm.response.to.have.status(200);
}); 

const jsonData = pm.response.json();

pm.test("Response contains the Correct Number of Valid Users", function () {
    pm.expect(Object.keys(jsonData).length).to.eql(4);
});

pm.test("Response contains all Valid Users", function () {
    pm.expect(jsonData[0].email).to.eql("admin@example.com");
    pm.expect(jsonData[1].email).to.eql("user2@facebook.com");
    pm.expect(jsonData[2].email).to.eql("user4@yahoo.com");
    pm.expect(jsonData[3].email).to.eql("user6@google.com");
});

pm.test("Response does contain any Invalid Users", function () {
    pm.expect(pm.response.text()).to.not.include("user1@c19add0f-f528-467d-b71b-7f863b1735e0.com");
    pm.expect(pm.response.text()).to.not.include("user3@d15b127f-ad53-4945-92e0-7a2bdecc926d.com");
    pm.expect(pm.response.text()).to.not.include("user5@02a34f9f-d601-417d-9f8a-0e80350b0217.com");
});

```